### PR TITLE
feat: Adiçao do campo observaçao nos pedidos

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "0.1.0",
 	"scripts": {
 		"ng": "ng",
-		"start": "ng serve -o",
+		"start": "ng serve --host 0.0.0.0",
 		"build": "ng build",
 		"build-dev": "ng build -c development",
 		"watch": "ng build --watch --configuration development",

--- a/src/app/modules/comandas/components/comanda-view/comanda-view.component.html
+++ b/src/app/modules/comandas/components/comanda-view/comanda-view.component.html
@@ -14,6 +14,7 @@
       <span class="label">Valor total:</span>
       <span class="valor"> {{getValorToral(item) | currency:"BRL"}}</span>
    </div>
+   <app-observacao [pedido]="item"></app-observacao>
 
    <mat-accordion>
       <mat-expansion-panel [expanded]="true">

--- a/src/app/modules/comandas/components/comanda-view/comanda-view.component.ts
+++ b/src/app/modules/comandas/components/comanda-view/comanda-view.component.ts
@@ -19,7 +19,6 @@ export class ComandaViewComponent implements OnInit {
 	) { }
 
 	ngOnInit(): void {
-		console.log(this.data);
 	}
 
 	getStatusProdutoPedido(status: EnumStatusProdutoDoPedido) {

--- a/src/app/modules/pedidos/components/pedidos-item/pedidos-item.component.css
+++ b/src/app/modules/pedidos/components/pedidos-item/pedidos-item.component.css
@@ -25,7 +25,6 @@
 
 .descricao-icone {
    transform: scale(0.8);
-   margin-right: 5px;
    vertical-align: middle;
 }
 
@@ -38,6 +37,7 @@
 
 mat-icon {
    color: var(--icon-color);
+   margin-right: 5px;
 }
 
 .icone-cancelar {

--- a/src/app/modules/pedidos/components/pedidos-item/pedidos-item.component.html
+++ b/src/app/modules/pedidos/components/pedidos-item/pedidos-item.component.html
@@ -1,32 +1,39 @@
 <div class="container">
-
-   <div class="imagem-produto">
-      <img src='data:image/png;base64,{{pedido.fotoProdutoDoPedido}}' />
-   </div>
-
-   <div class="container-descricao">
-      <div class="descricao">
-         <mat-icon class="descricao-icone">lunch_dining</mat-icon>
-         {{pedido.nomeProdutoDoPedido}}
-      </div>
-      <div class="descricao">
-         <mat-icon class="descricao-icone">receipt</mat-icon>
-         {{pedido.nomeComanda}} / Comanda {{pedido.idComanda}}
-      </div>
-      <div class="descricao">
-         <mat-icon class="descricao-icone">shopping_basket</mat-icon>
-         {{pedido.quantidadeProdutoDoPedido}}x
+   <div class="coluna-imagem">
+      <div class="imagem-produto">
+         <img src='data:image/png;base64,{{pedido.fotoProdutoDoPedido}}' />
       </div>
    </div>
 
-   <mat-icon class="icone-cancelar grow"
-      [matTooltip]="'Cancelar produto'"
-      [matTooltipPosition]="'below'"
-      (click)="onCancell()">
-      cancel
-   </mat-icon>
+   <div class="coluna-descricao">
+      <div class="container-descricao">
+         <div class="descricao">
+            <mat-icon class="descricao-icone">lunch_dining</mat-icon>
+            {{pedido.nomeProdutoDoPedido}}
+         </div>
+         <div class="descricao">
+            <mat-icon class="descricao-icone">receipt</mat-icon>
+            {{pedido.nomeComanda}} / Comanda {{pedido.idComanda}}
+         </div>
+         <div class="descricao">
+            <mat-icon class="descricao-icone">shopping_basket</mat-icon>
+            {{pedido.quantidadeProdutoDoPedido}}x
+         </div>
+      </div>
+   </div>
 
-   <div class="data-hora-pedido">
-      {{pedido.dataHoraPedido | date: 'HH:mm a'}}
+   <div class="coluna-acoes">
+      <mat-icon class="icone-cancelar grow"
+         [matTooltip]="'Cancelar produto'"
+         [matTooltipPosition]="'below'"
+         (click)="onCancell()">
+         cancel
+      </mat-icon>
+
+      <div class="data-hora-pedido">
+         {{pedido.dataHoraPedido | date: 'HH:mm a'}}
+      </div>
    </div>
 </div>
+
+<app-observacao [pedido]="pedido"></app-observacao>

--- a/src/app/modules/pedidos/components/shared-styles.css
+++ b/src/app/modules/pedidos/components/shared-styles.css
@@ -93,3 +93,10 @@
    align-content: center;
    margin: auto;
 }
+
+.cdk-drag-preview {
+   box-sizing: border-box;
+   box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2),
+      0 8px 10px 1px rgba(0, 0, 0, 0.14),
+      0 3px 14px 2px rgba(0, 0, 0, 0.12);
+}

--- a/src/app/modules/pedidos/components/shared-styles.css
+++ b/src/app/modules/pedidos/components/shared-styles.css
@@ -52,7 +52,7 @@
    cursor: move;
    background: white;
    font-size: 14px;
-   max-height: 120px;
+   max-height: auto;
    min-height: 120px;
    overflow: hidden;
 }

--- a/src/app/modules/pedidos/models/pedido-view.model.ts
+++ b/src/app/modules/pedidos/models/pedido-view.model.ts
@@ -15,4 +15,5 @@ export interface PedidoViewModel {
 	quantidadeProdutoDoPedido: number;
 	statusProdutoDoPedido: EnumStatusProdutoDoPedido;
 	dataHoraPedido?: Date;
+	observacao?: string;
 }

--- a/src/app/modules/pedidos/models/pedido.model.ts
+++ b/src/app/modules/pedidos/models/pedido.model.ts
@@ -7,4 +7,5 @@ import { ProdutoPedido } from "./produto-pedido.model";
 export interface Pedido extends BaseModel {
 	produtosDoPedido: ProdutoPedido[];
 	dataHoraPedido?: Date;
+	observacao?: string;
 }

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -8,6 +8,7 @@ import { NgxImageCompressService } from "ngx-image-compress";
 import { PaginaEmConstrucaoComponent } from "./pages/pagina-em-construcao/pagina-em-construcao.component";
 import { PaginaNaoEncontradaComponent } from './pages/pagina-nao-encontrada/pagina-nao-encontrada.component';
 import { FileUploadComponent } from './utils/components/file-upload/file-upload.component';
+import { ObservacaoComponent } from './utils/components/observacao/observacao.component';
 import { ClickStopPropagationDirective } from "./utils/directives/click-stop-propagation.directive";
 
 @NgModule({
@@ -15,7 +16,8 @@ import { ClickStopPropagationDirective } from "./utils/directives/click-stop-pro
 		PaginaEmConstrucaoComponent,
 		PaginaNaoEncontradaComponent,
 		ClickStopPropagationDirective,
-		FileUploadComponent
+		FileUploadComponent,
+		ObservacaoComponent
 	],
 	imports: [
 		CommonModule,
@@ -29,7 +31,8 @@ import { ClickStopPropagationDirective } from "./utils/directives/click-stop-pro
 		PaginaNaoEncontradaComponent,
 		ClickStopPropagationDirective,
 		FileUploadComponent,
-		MatTooltipModule
+		MatTooltipModule,
+		ObservacaoComponent
 	],
 	providers: [
 		NgxImageCompressService

--- a/src/app/shared/utils/components/observacao/observacao.component.css
+++ b/src/app/shared/utils/components/observacao/observacao.component.css
@@ -1,0 +1,21 @@
+.container-observacao {
+   width: auto;
+   display: flex;
+   margin: 10px 0 4px 0;
+   background-color: #ecd1361e;
+   border-color: #f3f023;
+   border-style: dashed;
+   border-width: 2px;
+   border-radius: 4px;
+   padding: 8px;
+}
+
+.observacao {
+   display: flex;
+   align-items: center;
+}
+
+mat-icon {
+   color: var(--icon-color);
+   margin-right: 5px;
+}

--- a/src/app/shared/utils/components/observacao/observacao.component.html
+++ b/src/app/shared/utils/components/observacao/observacao.component.html
@@ -1,0 +1,7 @@
+<div class="container-observacao"
+   *ngIf="pedido.observacao">
+   <div class="observacao">
+      <mat-icon class="observacao-icone">info</mat-icon>
+      Observaçao: {{pedido.observacao}}
+   </div>
+</div>

--- a/src/app/shared/utils/components/observacao/observacao.component.spec.ts
+++ b/src/app/shared/utils/components/observacao/observacao.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ObservacaoComponent } from './observacao.component';
+
+describe('ObservacaoComponent', () => {
+  let component: ObservacaoComponent;
+  let fixture: ComponentFixture<ObservacaoComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ObservacaoComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ObservacaoComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/utils/components/observacao/observacao.component.ts
+++ b/src/app/shared/utils/components/observacao/observacao.component.ts
@@ -1,0 +1,18 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { Pedido } from 'src/app/modules/pedidos/models/pedido.model';
+import { PedidoViewModel } from './../../../../modules/pedidos/models/pedido-view.model';
+
+@Component({
+	selector: 'app-observacao[pedido]',
+	templateUrl: './observacao.component.html',
+	styleUrls: [ './observacao.component.css' ]
+})
+export class ObservacaoComponent implements OnInit {
+
+	@Input() pedido!: Pedido | PedidoViewModel;
+
+	constructor () { }
+
+	ngOnInit(): void {
+	}
+}


### PR DESCRIPTION
Requisito 1: Adicionar campo de observação no card do quadro de pedidos #45

Requisito 2: Adicionar campo de observação no detalhes do pedido quando
clica no "i" na listagem de comandas #46

Soluçao: Implementaçao de um componente compartilhado usado para exibir
a observaçao nas telas requisitadas

Close #45
Close #46