### PR TITLE
fix: Impede atualizaçao das filas enquanto o usuário esta arrastando

### DIFF
--- a/src/app/modules/pedidos/components/pedidos-cozinhando/pedidos-cozinhando.component.html
+++ b/src/app/modules/pedidos/components/pedidos-cozinhando/pedidos-cozinhando.component.html
@@ -23,7 +23,9 @@
 
       <div class="itens-lista"
          *ngFor="let item of pedidosCozinhando"
-         cdkDrag>
+         cdkDrag
+         (cdkDragStarted)="podeAtualizar(false)"
+         (cdkDragDropped)="podeAtualizar()">
          <div class="custom-placeholder"
             *cdkDragPlaceholder></div>
          <app-pedidos-item [pedido]="item"></app-pedidos-item>

--- a/src/app/modules/pedidos/components/pedidos-cozinhando/pedidos-cozinhando.component.ts
+++ b/src/app/modules/pedidos/components/pedidos-cozinhando/pedidos-cozinhando.component.ts
@@ -1,5 +1,5 @@
 import { CdkDragDrop, moveItemInArray } from "@angular/cdk/drag-drop";
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, Input, OnDestroy } from '@angular/core';
 import { SubscriptionContainer } from "src/app/core/helpers/subscription-container";
 import { EnumStatusProdutoDoPedido } from "src/app/shared/models/enums/status-produto-pedido.enum";
 import { PedidoViewModel } from "../../models/pedido-view.model";
@@ -12,7 +12,7 @@ import { PedidosState } from "../../state/pedidos-state";
 	templateUrl: './pedidos-cozinhando.component.html',
 	styleUrls: [ '../shared-styles.css' ]
 })
-export class PedidosCozinhandoComponent implements OnInit, OnDestroy {
+export class PedidosCozinhandoComponent implements OnDestroy {
 
 	@Input() carregando: boolean = true;
 	pedidosCozinhando: PedidoViewModel[] = [];
@@ -31,9 +31,6 @@ export class PedidosCozinhandoComponent implements OnInit, OnDestroy {
 		});
 	}
 
-	ngOnInit(): void {
-	}
-
 	ngOnDestroy(): void {
 		this.subscriptions.dispose();
 	}
@@ -46,5 +43,9 @@ export class PedidosCozinhandoComponent implements OnInit, OnDestroy {
 		else {
 			this.produtosPedidoService.atualizarStatusProdutoPedido(event, EnumStatusProdutoDoPedido.Cozinhando);
 		}
+	}
+
+	podeAtualizar(value: boolean = true) {
+		this.pedidoService.podeAtualizarListas = value;
 	}
 }

--- a/src/app/modules/pedidos/components/pedidos-pendentes/pedidos-pendentes.component.html
+++ b/src/app/modules/pedidos/components/pedidos-pendentes/pedidos-pendentes.component.html
@@ -23,7 +23,9 @@
 
       <div class="itens-lista"
          *ngFor="let item of pedidosPendentes"
-         cdkDrag>
+         cdkDrag
+         (cdkDragStarted)="podeAtualizar(false)"
+         (cdkDragDropped)="podeAtualizar()">
          <div class="custom-placeholder"
             *cdkDragPlaceholder></div>
          <app-pedidos-item [pedido]="item"></app-pedidos-item>

--- a/src/app/modules/pedidos/components/pedidos-pendentes/pedidos-pendentes.component.ts
+++ b/src/app/modules/pedidos/components/pedidos-pendentes/pedidos-pendentes.component.ts
@@ -1,5 +1,5 @@
 import { CdkDragDrop, moveItemInArray } from "@angular/cdk/drag-drop";
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, Input, OnDestroy } from '@angular/core';
 import { SubscriptionContainer } from "src/app/core/helpers/subscription-container";
 import { EnumStatusProdutoDoPedido } from "src/app/shared/models/enums/status-produto-pedido.enum";
 import { PedidoViewModel } from "../../models/pedido-view.model";
@@ -12,7 +12,7 @@ import { PedidosState } from "../../state/pedidos-state";
 	templateUrl: './pedidos-pendentes.component.html',
 	styleUrls: [ '../shared-styles.css' ]
 })
-export class PedidosPendentesComponent implements OnInit, OnDestroy {
+export class PedidosPendentesComponent implements OnDestroy {
 
 	@Input() carregando: boolean = true;
 	pedidosPendentes: PedidoViewModel[] = [];
@@ -30,9 +30,6 @@ export class PedidosPendentesComponent implements OnInit, OnDestroy {
 		});
 	}
 
-	ngOnInit(): void {
-	}
-
 	ngOnDestroy(): void {
 		this.subscriptions.dispose();
 	}
@@ -45,5 +42,9 @@ export class PedidosPendentesComponent implements OnInit, OnDestroy {
 		else {
 			this.produtosPedidoService.atualizarStatusProdutoPedido(event, EnumStatusProdutoDoPedido.Pendente);
 		}
+	}
+
+	podeAtualizar(value: boolean = true) {
+		this.pedidoService.podeAtualizarListas = value;
 	}
 }

--- a/src/app/modules/pedidos/components/pedidos-prontos/pedidos-prontos.component.html
+++ b/src/app/modules/pedidos/components/pedidos-prontos/pedidos-prontos.component.html
@@ -23,7 +23,9 @@
 
       <div class="itens-lista"
          *ngFor="let item of pedidosProntos"
-         cdkDrag>
+         cdkDrag
+         (cdkDragStarted)="podeAtualizar(false)"
+         (cdkDragDropped)="podeAtualizar()">
          <div class="custom-placeholder"
             *cdkDragPlaceholder></div>
          <app-pedidos-item [pedido]="item"></app-pedidos-item>

--- a/src/app/modules/pedidos/components/pedidos-prontos/pedidos-prontos.component.ts
+++ b/src/app/modules/pedidos/components/pedidos-prontos/pedidos-prontos.component.ts
@@ -46,4 +46,8 @@ export class PedidosProntosComponent implements OnInit, OnDestroy {
 			this.produtosPedidoService.atualizarStatusProdutoPedido(event, EnumStatusProdutoDoPedido.Pronto);
 		}
 	}
+
+	podeAtualizar(value: boolean = true) {
+		this.pedidoService.podeAtualizarListas = value;
+	}
 }

--- a/src/app/modules/pedidos/containers/pedidos-list/pedidos-list.component.ts
+++ b/src/app/modules/pedidos/containers/pedidos-list/pedidos-list.component.ts
@@ -27,7 +27,7 @@ export class PedidosListComponent implements OnInit, OnDestroy {
 		this.scheduler = setInterval(() => {
 			if (this.pedidosService.podeAtualizarListas)
 				this.atualizarDados();
-		}, 5000);
+		}, 20000);
 	}
 
 	ngOnDestroy(): void {

--- a/src/app/modules/pedidos/containers/pedidos-list/pedidos-list.component.ts
+++ b/src/app/modules/pedidos/containers/pedidos-list/pedidos-list.component.ts
@@ -25,8 +25,9 @@ export class PedidosListComponent implements OnInit, OnDestroy {
 
 	ngOnInit(): void {
 		this.scheduler = setInterval(() => {
-			this.atualizarDados();
-		}, 30000);
+			if (this.pedidosService.podeAtualizarListas)
+				this.atualizarDados();
+		}, 5000);
 	}
 
 	ngOnDestroy(): void {

--- a/src/app/modules/pedidos/services/pedidos.service.ts
+++ b/src/app/modules/pedidos/services/pedidos.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from "@angular/common/http";
 import { Injectable } from '@angular/core';
-import { tap } from "rxjs";
+import { BehaviorSubject, tap } from "rxjs";
 import { ResponseModel } from "src/app/core/models/response.model";
 import { GenericApi } from "src/app/core/services/generic-api.service";
 import { PedidoViewModel } from '../models/pedido-view.model';
@@ -13,12 +13,22 @@ import { PedidosState } from "../state/pedidos-state";
 @Injectable()
 export class PedidosService extends GenericApi<Pedido> {
 
+	private podeAtualizarSubject: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(true);
+
 	/**
 	 * Inicia uma nova instância de {@link PedidosService}
 	 * @param http O {@link HttpClient} do serviço.
 	 */
 	constructor (http: HttpClient, private state: PedidosState) {
 		super(http, "/pedidos");
+	}
+
+	public get podeAtualizarListas() {
+		return this.podeAtualizarSubject.value;
+	}
+
+	public set podeAtualizarListas(value: boolean) {
+		this.podeAtualizarSubject.next(value);
 	}
 
 	/**


### PR DESCRIPTION
Requisito: Pode ocorrer de a tela da fila de pedidos atualizar no
momento em que o usuário está arrastando um item. Se isso acontecer, a
ação que o usuário estava executando será interrompida de imediato, o
que pode deixa-lo confuso sem saber se o item foi atualizado ou não e
ainda o obrigará a executar novamente a açao de selecionar o item para
arrastar.

Soluçao: Adiciona um subject utilizado pelas listas. Sempre que o
usuário começa a arrastar um item este subject emite um evento dizendo
que as listas não podem ser atualizadas. O oposto ocorre quando o
usuário solta um item na lista

Close #48